### PR TITLE
Ops DB maint - delete expired API tokens

### DIFF
--- a/frontend/abvid_reporting.py
+++ b/frontend/abvid_reporting.py
@@ -1,15 +1,12 @@
-import os
-import sys
-from email.mime.text import MIMEText
-from datetime import date
-import boto.ses
-from VEDA.utils import get_config
-
 '''
 ABVID REPORTING - email / etc.
 
 '''
+import boto.ses
+from django.core.exceptions import ObjectDoesNotExist
+
 from frontend_env import *
+from VEDA.utils import get_config
 
 '''
 v1 = Video.objects.filter(edx_id = upload_info['edx_id'])

--- a/scripts/delete_expired_tokens.py
+++ b/scripts/delete_expired_tokens.py
@@ -1,0 +1,29 @@
+"""
+Destroy Out of date tokens
+"""
+import os
+import sys
+import datetime
+from datetime import timedelta
+
+project_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_path not in sys.path:
+    sys.path.append(project_path)
+
+from control.control_env import *
+
+from oauth2_provider.models import AccessToken
+
+
+def get_tokens():
+    auth_query = AccessToken.objects.filter(
+        expires__lt=datetime.datetime.now() - timedelta(hours=1),
+    )
+    for a in auth_query:
+        AccessToken.objects.filter(token=a.token).delete()
+        print a.token
+    print len(auth_query)
+
+
+if __name__ == '__main__':
+    get_tokens()


### PR DESCRIPTION
## VEDA-OPS

### Description
Add one-off task to scripts folder to delete expired API tokens (>1m as of 10.1.17)

### Testing
- [ ] Unit tests

FYI: @edx/educator-neem @edx/educator-mallow

### Post-review
- [ ] Rebase and squash commits
