### PR TITLE
Add `options` to avoid multiple Cielo24 callbacks.

### DIFF
--- a/VEDA_OS01/transcripts.py
+++ b/VEDA_OS01/transcripts.py
@@ -34,7 +34,9 @@ ERROR = 'error'
 
 # Transcript format
 TRANSCRIPT_SJSON = 'sjson'
-CIELO24_TRANSCRIPT_COMPLETED = django.dispatch.Signal(providing_args=['job_id', 'lang_code', 'org', 'video_id'])
+CIELO24_TRANSCRIPT_COMPLETED = django.dispatch.Signal(providing_args=[
+    'job_id', 'iwp_name', 'lang_code', 'org', 'video_id'
+])
 CONFIG = utils.get_config()
 
 # Cielo24 API URLs
@@ -129,7 +131,7 @@ class Cielo24CallbackHandlerView(APIView):
         """
         Handle Cielo24 callback request.
         """
-        required_attrs = ('job_id', 'lang_code', 'org', 'video_id')
+        required_attrs = ('job_id', 'iwp_name', 'lang_code', 'org', 'video_id')
         missing = [attr for attr in required_attrs if attr not in request.query_params.keys()]
         if missing:
             LOGGER.warning(
@@ -142,6 +144,7 @@ class Cielo24CallbackHandlerView(APIView):
             sender=self,
             org=request.query_params['org'],
             job_id=request.query_params['job_id'],
+            iwp_name=request.query_params['iwp_name'],
             video_id=request.query_params['video_id'],
             lang_code=request.query_params['lang_code'],
         )
@@ -162,14 +165,17 @@ def cielo24_transcript_callback(sender, **kwargs):
     org = kwargs['org']
     job_id = kwargs['job_id']
     video_id = kwargs['video_id']
+    iwp_name = kwargs['iwp_name']
     lang_code = kwargs['lang_code']
 
     LOGGER.info(
-        '[CIELO24 TRANSCRIPTS] Transcript complete request received for video=%s -- org=%s -- lang=%s -- job_id=%s',
+        '[CIELO24 TRANSCRIPTS] Transcript complete request received for '
+        'video=%s -- org=%s -- lang=%s -- job_id=%s -- iwp_name=%s',
         video_id,
         org,
         lang_code,
-        job_id
+        job_id,
+        iwp_name
     )
 
     # get transcript credentials for an organization

--- a/control/tests/test_deliver_cielo.py
+++ b/control/tests/test_deliver_cielo.py
@@ -149,11 +149,13 @@ class Cielo24TranscriptTests(TestCase):
                         lang_code='TARGET_LANG',
                         video_id='12345',
                         job_id='000-111-222',
+                        iwp_name='{iwp_name}',
                         org='MAx',
                     ),
                     api_token='cielo24_api_key',
                     priority='PRIORITY',
                     transcription_fidelity='PROFESSIONAL',
+                    options='{"return_iwp": ["FINAL"]}'
                 ),
                 'body': None,
                 'method': 'GET'

--- a/control/veda_deliver_cielo.py
+++ b/control/veda_deliver_cielo.py
@@ -3,7 +3,7 @@ Cielo24 Integration
 """
 import ast
 import logging
-import urllib
+import json
 
 import requests
 from requests.packages.urllib3.exceptions import InsecurePlatformWarning
@@ -119,6 +119,7 @@ class Cielo24Transcript(object):
         callback_url = build_url(
             self.callback_base_url,
             job_id=job_id,
+            iwp_name='{iwp_name}',
             lang_code=lang_code,
             org=self.org,
             video_id=self.video.studio_id
@@ -135,6 +136,7 @@ class Cielo24Transcript(object):
                 api_token=self.api_key,
                 priority=self.turnaround,
                 transcription_fidelity=self.fidelity,
+                options=json.dumps({"return_iwp": ["FINAL"]})
             )
         )
 


### PR DESCRIPTION
[EDUCATOR-1439](https://openedx.atlassian.net/browse/EDUCATOR-1439)
```bash
perform_transcription(
    transcription_fidelity='Professional',
    priority='STANDARD ',
    callback_url='http://YOURURLHERE/cielo24_calllback?iwp_name={iwp_name}& ...',
    options='{"return_iwp":["FINAL"]}'
)
```