### PR TITLE
Fix drf and django filter versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 ## NOTE: This is not a working req file -- merely a collection for notes.
 django==1.9
-djangorestframework
+djangorestframework==3.6.4
 django-cors-headers
 django-oauth-toolkit==0.11.0
-django-filter
+django-filter==1.0.4
 newrelic
 uwsgi
 pysftp


### PR DESCRIPTION
**Issue**: ImportError: Could not import `'rest_framework.filters.DjangoFilterBackend'`

DRF-3.7.0 has removed `DjangoFilterBackend`, if we want to move to DRF-3.7.0, we shall be using `'django_filters.rest_framework.DjangoFilterBackend'` instead.