### PR TITLE
add urls to logs

### DIFF
--- a/VEDA/tests/test_utils.py
+++ b/VEDA/tests/test_utils.py
@@ -147,3 +147,30 @@ class UtilTests(TestCase):
         """
         instance_config = utils.get_config()
         self.assertDictEqual(instance_config, TEST_CONFIG)
+
+    @data(
+        {
+            'url': 'http://sandbox.edx.org/do?aaa=11&vvv=234',
+            'params_to_scrub': ['aaa'],
+            'expected_url': 'http://sandbox.edx.org/do?vvv=234&aaa=XX'
+        },
+        {
+            'url': 'http://sandbox.edx.org/do?aaa=1&vvv=234',
+            'params_to_scrub': ['aaa', 'vvv'],
+            'expected_url': 'http://sandbox.edx.org/do?vvv=XXX&aaa=X'
+        },
+        {
+            'url': 'http://sandbox.edx.org/do?aaa=1&vvv=234',
+            'params_to_scrub': ['zzzz'],
+            'expected_url': 'http://sandbox.edx.org/do?vvv=234&aaa=1'
+        },
+    )
+    @unpack
+    def test_scrub_query_params(self, url, params_to_scrub, expected_url):
+        """
+        Tests that utils.scrub_query_params works as expected.
+        """
+        self.assertEqual(
+            utils.scrub_query_params(url, params_to_scrub),
+            expected_url
+        )

--- a/VEDA_OS01/tests/test_transcripts.py
+++ b/VEDA_OS01/tests/test_transcripts.py
@@ -17,7 +17,7 @@ from moto import mock_s3_deprecated
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from VEDA.utils import get_config, build_url
+from VEDA.utils import get_config, build_url, scrub_query_params
 from VEDA_OS01 import transcripts, utils
 from VEDA_OS01.models import (Course, TranscriptCredentials,
                               TranscriptProcessMetadata, TranscriptProvider,
@@ -1279,7 +1279,16 @@ class ThreePlayTranscriptionCallbackTest(APITestCase):
             {
                 'method': 'error',
                 'args': (
-                    '[3PlayMedia Task] Translations metadata request failed for video=%s -- process_id=%s -- status=%s',
+                    '[3PlayMedia Task] Translations metadata request failed, url=%s -- video=%s -- process_id=%s -- status=%s',  # pylint: disable=line-too-long
+                    scrub_query_params(
+                        build_url(
+                            transcripts.THREE_PLAY_TRANSLATIONS_METADATA_URL.format(
+                                file_id='112233',
+                            ),
+                            apikey='insecure_api_key'
+                        ),
+                        ['apikey']
+                    ),
                     VIDEO_DATA['studio_id'],
                     '112233',
                     400,

--- a/control/veda_deliver_3play.py
+++ b/control/veda_deliver_3play.py
@@ -8,7 +8,7 @@ import sys
 
 from requests.packages.urllib3.exceptions import InsecurePlatformWarning
 from VEDA_OS01.models import TranscriptProcessMetadata, TranscriptProvider, TranscriptStatus
-from VEDA.utils import build_url
+from VEDA.utils import build_url, scrub_query_params
 
 requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
 
@@ -94,7 +94,7 @@ class ThreePlayMediaClient(object):
             raise ThreePlayMediaUrlError('The URL "{media_url}" is not Accessible.'.format(media_url=self.media_url))
         elif response.headers['Content-Type'] != self.allowed_content_type:
             raise ThreePlayMediaUrlError(
-                'Media content-type should be "{allowed_type}". URL was "{media_url}", content-type was "{type}"'.format(
+                'Media content-type should be "{allowed_type}". URL was "{media_url}", content-type was "{type}"'.format(  # pylint: disable=line-too-long
                     allowed_type=self.allowed_content_type,
                     media_url=self.media_url,
                     type=response.headers['Content-Type'],
@@ -105,11 +105,16 @@ class ThreePlayMediaClient(object):
         """
         Gets all the 3Play Media supported languages
         """
-        response = requests.get(url=build_url(self.base_url, self.available_languages_url, apikey=self.api_key))
+        available_languages_url = build_url(self.base_url, self.available_languages_url, apikey=self.api_key)
+        response = requests.get(
+            url=available_languages_url
+        )
         if not response.ok:
             raise ThreePlayMediaLanguagesRetrievalError(
-                'Error while retrieving available languages: {response} -- {status}'.format(
-                    response=response.text, status=response.status_code
+                'Error while retrieving available languages: url={url} -- {response} -- {status}'.format(
+                    url=scrub_query_params(available_languages_url, ['apikey']),
+                    response=response.text,
+                    status=response.status_code
                 )
             )
 


### PR DESCRIPTION
[EDUCATOR-1631](https://openedx.atlassian.net/browse/EDUCATOR-1631)

This will add `3play` and `cielo24` api urls into logs in case of an error. But before logging, sensitive information will be scrubbed from api url