### PR TITLE
EDUCATOR 2938 Create HTTP video ingest API

### DIFF
--- a/VEDA/urls.py
+++ b/VEDA/urls.py
@@ -56,4 +56,9 @@ urlpatterns = [
         view=views.heartbeat,
         name='heartbeat'
     ),
+    url(
+        r'^api/ingest_from_s3/',
+        view=views.IngestFromS3View.as_view(),
+        name='ingest_from_s3'
+    )
 ]

--- a/VEDA_OS01/utils.py
+++ b/VEDA_OS01/utils.py
@@ -1,6 +1,8 @@
 """
 Common utils.
 """
+from rest_framework.parsers import BaseParser
+
 from VEDA.utils import get_config
 from VEDA_OS01.models import Encode, TranscriptStatus, URL, Video
 
@@ -107,3 +109,16 @@ def is_video_ready(edx_id, ignore_encodes=list()):
         ignore_encodes(list): A list containing the profiles that should not be considered.
     """
     return set(get_incomplete_encodes(edx_id)).issubset(set(ignore_encodes))
+
+
+class PlainTextParser(BaseParser):
+    """
+    Plain text parser.
+    """
+    media_type = 'text/plain'
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        """
+        Simply return a string representing the body of the request.
+        """
+        return stream.read()

--- a/control/veda_file_discovery.py
+++ b/control/veda_file_discovery.py
@@ -323,7 +323,7 @@ class FileDiscovery(object):
             if not file_downloaded:
                 # S3 Bucket ingest failed, move the file rejected directory.
                 self.move_video(video_s3_key, destination_dir=self.auth_dict['edx_s3_rejected_prefix'])
-                return
+                return False
 
             # Prepare to ingest.
             video_metadata = dict(
@@ -356,6 +356,9 @@ class FileDiscovery(object):
                 # Move the video file into 'prod-edx/processed' or 'stage-edx/processed
                 # directory, if ingestion is complete.
                 self.move_video(video_s3_key, destination_dir=self.auth_dict['edx_s3_processed_prefix'])
+
+            return ingest.complete
         else:
             # Reject the video file and update val status to 'invalid_token'
             self.reject_file_and_update_val(video_s3_key, filename, client_title, course_id)
+            return False


### PR DESCRIPTION
## [EDUCATOR-2938](https://openedx.atlassian.net/browse/EDUCATOR-2938)

HTTP endpoint to handle ingest notifications from s3, called by an SNS.

Permissions should probably be done [this way](https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.verify.signature.html?shortFooter=true)