### PR TITLE
Add 'no_audio' optional flag to HEAL command

### DIFF
--- a/bin/heal
+++ b/bin/heal
@@ -57,7 +57,8 @@ def main():
         {cmd} -c course_id
         {cmd} -s schedule
         {cmd} --process-translations
-        [-i -c -s --process-translations]
+        {cmd} --no_audio
+        [-i -c -s --process-translations --no_audio]
         Use --help to see all options.
         '''.format(cmd=sys.argv[0])
 
@@ -81,6 +82,12 @@ def main():
         '--process-translations',
         dest='process_translations',
         help='Retrieves completed 3PlayMedia translations for the videos.',
+        action='store_true'
+    )
+
+    parser.add_argument(
+        '--no_audio',
+        help='Removes audio_mp3 from encode list.',
         action='store_true'
     )
 
@@ -118,7 +125,8 @@ def main():
         VH = VedaHeal(
             video_query=Video.objects.filter(
                 edx_id=veda_id.strip()
-                )
+                ),
+            no_audio=args.no_audio
             )
         VH.send_encodes()
         return
@@ -130,7 +138,8 @@ def main():
                     institution=course_id[0:3],
                     edx_classid=course_id[3:8]
                     )
-                )
+                ),
+            no_audio=args.no_audio
             )
         VH.send_encodes()
         return

--- a/control/veda_heal.py
+++ b/control/veda_heal.py
@@ -45,6 +45,7 @@ class VedaHeal(object):
         self.freezing_bug = kwargs.get('freezing_bug', False)
         self.val_status = None
         self.retry_barrier_hours = 24
+        self.no_audio = kwargs.get('no_audio', False)
 
     def discovery(self):
         self.video_query = Video.objects.filter(
@@ -157,6 +158,8 @@ class VedaHeal(object):
         ).determine_encodes()
         try:
             if uncompleted_encodes:
+                if self.no_audio and 'audio_mp3' in uncompleted_encodes:
+                    uncompleted_encodes.remove('audio_mp3')
                 uncompleted_encodes.remove('review')
         except KeyError:
             pass


### PR DESCRIPTION
Added 'no_audio' optional flag to HEAL command, to skip over mp3 encoding if a video has no audio.