### PR TITLE
add default directory for uploads to 3play

### DIFF
--- a/control/tests/test_deliver_3play.py
+++ b/control/tests/test_deliver_3play.py
@@ -123,6 +123,7 @@ class ThreePlayMediaClientTests(TestCase):
             turnaround_level=self.video_transcript_preferences['turnaround_level'],
             callback_url=self.video_transcript_preferences['callback_url'],
             language_id=1,
+            batch_name='Default',
         )
 
         expected_requests = [

--- a/control/veda_deliver_3play.py
+++ b/control/veda_deliver_3play.py
@@ -78,6 +78,7 @@ class ThreePlayMediaClient(object):
         self.upload_media_file_url = u'files/'
         self.available_languages_url = u'caption_imports/available_languages/'
         self.allowed_content_type = u'video/mp4'
+        self.default_dir = 'Default'
 
     def validate_media_url(self):
         """
@@ -157,6 +158,7 @@ class ThreePlayMediaClient(object):
             api_secret_key=self.api_secret,
             turnaround_level=self.turnaround_level,
             callback_url=self.callback_url,
+            batch_name=self.default_dir,
         )
 
         available_languages = self.get_available_languages()


### PR DESCRIPTION
## [EDUCATOR-3391](https://openedx.atlassian.net/browse/EDUCATOR-3391)

### Description
3plyaMedia have updated their API. This has caused the failure of existing 3Play integrations in edx video pipeline. In this PR we are specifying a folder to keep files in it, as per new update in 3Play, following behavior is expected
> Alternatively, you can upload to a specific folder with the batch_name attribute. If a folder with that name already exists, the file will go there. If it does not exist, it will be created for you.

>If a folder is not specified, or the specified folder is not found, the upload will go into your last created folder. If you have no folders on file, the file will go into a new folder named "API Upload Folder".