### PR TITLE
Fix the about video ingest with names containing brackets

### DIFF
--- a/control/veda_file_ingest.py
+++ b/control/veda_file_ingest.py
@@ -131,7 +131,9 @@ class VedaIngest(object):
             .replace('\'', '\\\'') \
             .replace('[', '\[') \
             .replace(']', '\]') \
-            .replace('&', '\&')
+            .replace('&', '\&') \
+            .replace('(', '\(') \
+            .replace(')', '\)')
 
         ff_command = ' '.join((
             FFPROBE,


### PR DESCRIPTION
@yro Please review
We had another about video ingest breakage, because the video name to be ingested was
`MOOC_Promo_004_Valoración_Financiera_Comprimido (1).m4v`. Note the bracket in the name. That introduced problems with ffprobe
