### PR TITLE
Fix the kombu dependency that broke the redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-oauth-toolkit==0.11.0
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
 edx-opaque-keys==0.4
+kombu==4.2.0
 newrelic
 uwsgi
 pysftp


### PR DESCRIPTION
This fix is made according to the conversation at https://github.com/celery/celery/issues/5369
Without this fix, we would encounter the following error on app start:
```
VersionMismatch: Redis transport requires redis-py versions 3.2.0 or later. You have 2.10.6
```