### PR TITLE
Remove unneeded dependency on gunicorn package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ urllib3==1.25.3
 celery==4.1.1
 pysrt==1.1.1
 MySQL-python==1.2.5
-gunicorn==0.17.4
 gevent==1.2.2
 six==1.11.0
 redis==2.10.6


### PR DESCRIPTION
We were getting a security alert due to a very old version of gunicorn that we had listed in our requirements.txt file, but it turns out that we are not using this package, and it is not a dependency of anything that we are using.