### PR TITLE
PROD-549: Use Django Oauth Toolkit for authentication.

### DIFF
--- a/VEDA/settings/base.py
+++ b/VEDA/settings/base.py
@@ -115,15 +115,6 @@ DATABASES = {
     }
 }
 
-# NOTE: JWT_SECRET_KEY is intentionally not set here to avoid production releases with a public value.
-# Set a value in a downstream settings file.
-JWT_AUTH = {
-    'JWT_AUDIENCE': 'video-pipeline',
-    'JWT_ISSUER': 'video-pipeline',
-    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
-    'JWT_VERIFY_AUDIENCE': False,
-}
-
 REST_FRAMEWORK = {
     'PAGE_SIZE': 10,
     'DEFAULT_PARSER_CLASSES': (

--- a/VEDA/settings/local.py
+++ b/VEDA/settings/local.py
@@ -22,13 +22,6 @@ DATABASES = {
 }
 # END DATABASE CONFIGURATION
 
-JWT_AUTH.update({
-    'JWT_SECRET_KEY': 'lms-secret',
-    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
-    'JWT_AUDIENCE': 'lms-key',
-    'JWT_VERIFY_AUDIENCE': False
-})
-
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 
 # See if the developer has any local overrides.

--- a/VEDA/settings/production.py
+++ b/VEDA/settings/production.py
@@ -30,9 +30,4 @@ for key, value in dict_updates.items():
 
 vars().update(CONFIG_DATA)
 
-JWT_AUTH = {
-    'JWT_SECRET_KEY': CONFIG_DATA['val_secret_key'],
-    'JWT_ISSUER': '{}/oauth2'.format(CONFIG_DATA['lms_base_url'].rstrip('/')),
-    'JWT_AUDIENCE': CONFIG_DATA['val_client_id'],
-    'JWT_VERIFY_AUDIENCE': True,
-}
+

--- a/VEDA/settings/stage.py
+++ b/VEDA/settings/stage.py
@@ -26,10 +26,3 @@ DATABASES = {
         'PORT': '',
     }
 }
-
-JWT_AUTH = {
-    'JWT_SECRET_KEY': CONFIG_DATA['val_secret_key'],
-    'JWT_ISSUER': '{}/oauth2'.format(CONFIG_DATA['lms_base_url'].rstrip('/')),
-    'JWT_AUDIENCE': CONFIG_DATA['val_client_id'],
-    'JWT_VERIFY_AUDIENCE': True,
-}

--- a/control/tests/test_deliver.py
+++ b/control/tests/test_deliver.py
@@ -4,6 +4,7 @@ Veda Delivery unit tests
 from __future__ import absolute_import
 import os
 import unittest
+import datetime
 
 from django.test import TestCase
 
@@ -54,13 +55,13 @@ class VedaDeliverRunTest(TestCase):
         )
 
     @patch('control.veda_val.VALAPICall._AUTH', PropertyMock(return_value=lambda: CONFIG_DATA))
+    @patch('control.veda_val.OAuthAPIClient.request')
     @responses.activate
-    def test_run(self):
+    def test_run(self, _):
         """
         Test of HLS run-through function
         """
         # VAL Patching
-        responses.add(responses.POST, CONFIG_DATA['val_token_url'], '{"access_token": "1234567890"}', status=200)
         responses.add(
             responses.GET,
             CONFIG_DATA['val_api_url'] + '/XXXXXXXX2014-V00TES1',
@@ -154,13 +155,13 @@ class VedaDeliverRunTest(TestCase):
         self.assertTrue(self.deliver_instance._VALIDATE_URL())
 
     @patch('control.veda_val.VALAPICall._AUTH', PropertyMock(return_value=lambda: CONFIG_DATA))
+    @patch('control.veda_val.OAuthAPIClient.request')
     @responses.activate
-    def test_update_data(self):
+    def test_update_data(self, _):
         """
         Run test of VAL status / call
         """
         # VAL Patching
-        responses.add(responses.POST, CONFIG_DATA['val_token_url'], '{"access_token": "1234567890"}', status=200)
         responses.add(
             responses.GET,
             CONFIG_DATA['val_api_url'] + '/XXXXXXXX2014-V00TES1',

--- a/control/tests/test_heal.py
+++ b/control/tests/test_heal.py
@@ -74,8 +74,9 @@ class HealTests(TestCase):
         url.save()
 
     @patch('control.veda_heal.VALAPICall._AUTH', PropertyMock(return_value=lambda: CONFIG_DATA))
+    @patch('control.veda_val.OAuthAPIClient')
     @responses.activate
-    def test_heal(self):
+    def test_heal(self, mock_client_init):
         val_response = {
             'courses': [{u'WestonHS/PFLC1x/3T2015': None}],
             'encoded_videos': [{
@@ -85,12 +86,6 @@ class HealTests(TestCase):
                 'profile': 'mobile_low',
             }]
         }
-        responses.add(
-            responses.POST,
-            CONFIG_DATA['val_token_url'],
-            '{"access_token": "1234567890"}',
-            status=200
-        )
         responses.add(
             responses.GET,
             build_url(CONFIG_DATA['val_api_url'], self.video_id),

--- a/control/tests/test_val.py
+++ b/control/tests/test_val.py
@@ -1,12 +1,11 @@
 
 from __future__ import absolute_import
-import ast
 import os
 import sys
 from django.test import TestCase
 from ddt import data, ddt, unpack
 
-from mock import PropertyMock, patch
+from mock import Mock, PropertyMock, patch
 
 import requests
 import urllib3
@@ -31,7 +30,6 @@ CONFIG_DATA = utils.get_config('test_config.yaml')
 
 @ddt
 class TestVALAPI(TestCase):
-
     def setUp(self):
         self.VP = VideoProto(
             client_title='Test Title',
@@ -48,15 +46,13 @@ class TestVALAPI(TestCase):
 
     def test_val_setup(self):
         # register val url to send api response
-        responses.add(responses.POST, CONFIG_DATA['val_token_url'], '{"access_token": "1234567890"}', status=200)
+        responses.add(responses.POST, CONFIG_DATA['oauth2_provider_url'], '{"access_token": "1234567890"}', status=200)
 
         salient_variables = [
             'val_api_url',
-            'val_client_id',
-            'val_password',
-            'val_secret_key',
-            'val_username',
-            'val_token_url',
+            'oauth2_client_id',
+            'oauth2_client_secret',
+            'oauth2_provider_url',
         ]
         for salient_variable in salient_variables:
             self.assertTrue(len(self.VAC.auth_dict[salient_variable]) > 0)
@@ -64,11 +60,7 @@ class TestVALAPI(TestCase):
     @responses.activate
     def test_val_connection(self):
         # register val url to send api response
-        responses.add(responses.POST, CONFIG_DATA['val_token_url'], '{"access_token": "1234567890"}', status=200)
         responses.add(responses.GET, CONFIG_DATA['val_api_url'], status=200)
-
-        self.VAC.val_tokengen()
-        self.assertFalse(self.VAC.val_token is None)
 
         response = requests.get(
             self.VAC.auth_dict['val_api_url'],

--- a/instance_config.yaml
+++ b/instance_config.yaml
@@ -74,15 +74,15 @@ instance_prefix: ''
 # ---
 # VAL user creds
 # ---
-val_token_url:
 val_api_url:
 val_video_images_url:
 val_transcript_create_url:
 val_video_transcript_status_url:
-val_client_id:
-val_secret_key:
-val_username: admin@example.com
-val_password:
+
+## OAUTH2 Provider
+oauth2_provider_url: 
+oauth2_client_id: 
+oauth2_client_secret: 
 
 ## VEDA API Auth
 veda_api_url:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-oauth-toolkit==0.11.0
 edx-django-utils==1.0.1
 edx-drf-extensions==2.0.0
 edx-opaque-keys==0.4
+edx-rest-api-client==1.9.2
 kombu==4.2.0
 newrelic
 uwsgi

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -28,15 +28,15 @@ transcript_provider_request_token: 1234a5a67cr890
 # VAL
 # ---
 val_api_url: http://val.edx.org/api
-val_token_url: http://val.edx.org/token
 val_video_images_url:
-# Credentials
-val_client_id: client
-val_secret_key: secret
-val_password: password
-val_username: username
 val_transcript_create_url: http://val.edx.org/transcript/create
 val_video_transcript_status_url: http://val.edx.org/video/status
+
+
+## OAUTH2 Provider
+oauth2_provider_url: http://localhost
+oauth2_client_id: vedatest
+oauth2_client_secret: secret
 
 celery_worker_high_queue: worker_high_queue
 celery_worker_medium_queue: worker_medium_queue


### PR DESCRIPTION
Changes the authentication method used within edx-video-pipeline to use Django Oauth Toolkit (DOT) for authentication, due to the previous method (DOP) being deprecated.