### PR TITLE
Fix 405 errors when uploading status for about videos.

### DIFF
--- a/control/veda_val.py
+++ b/control/veda_val.py
@@ -305,7 +305,7 @@ class VALAPICall(object):
         )
 
         r2 = self.oauth2_client.request('POST',
-                                        '/'.join((self.auth_dict['val_api_url'], self.video_proto.val_id)),
+                                        '/'.join((self.auth_dict['val_api_url'], '')),
                                         json=sending_data)
         if r2.status_code > 299:
             LOGGER.error('[API] : VAL POST {code}'.format(code=r2.status_code))


### PR DESCRIPTION
Due to a bug in a previous commit I was calling the wrong URL for updating video status.