### PR TITLE
add JWT_AUTH dict update at production

### DIFF
--- a/VEDA/settings/base.py
+++ b/VEDA/settings/base.py
@@ -163,7 +163,7 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 # more details on how to customize your logging configuration.
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 
-############### JWT Authentication  ####################
+# JWT Authentication Default configuration values
 
 JWT_AUTH = {
     'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',

--- a/VEDA/settings/base.py
+++ b/VEDA/settings/base.py
@@ -162,3 +162,19 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
+
+############### JWT Authentication  ####################
+
+JWT_AUTH = {
+    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
+    'JWT_ALGORITHM': 'HS256',
+    'JWT_VERIFY_EXPIRATION': True,
+    'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('preferred_username'),
+    'JWT_LEEWAY': 1,
+    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
+    'JWT_PUBLIC_SIGNING_JWK_SET': None,
+    'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
+    'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
+    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
+}

--- a/VEDA/settings/production.py
+++ b/VEDA/settings/production.py
@@ -18,7 +18,7 @@ LOGGING = get_logger_config(service_variant=CONFIG_DATA.get('SERVICE_VARIANT_NAM
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('DATABASES',)
+DICT_UPDATE_KEYS = ('DATABASES', 'JWT_AUTH')
 
 # Remove the items that should be used to update dicts, and apply them separately rather
 # than pumping them into the local vars.


### PR DESCRIPTION
### [PROD-1507](https://openedx.atlassian.net/browse/PROD-1507)

### Description
By defining a key in `DICT_UPDATE_KEYS`, the existing values are not overridden but updated with the values in the config file. JWT_AUTH is not among the values. This PR adds JWT_AUTH to that list and adds the set of default JWT_AUTH values that are missing in VEDA